### PR TITLE
Prevents double subscription

### DIFF
--- a/lib/live_ex.ex
+++ b/lib/live_ex.ex
@@ -31,6 +31,7 @@ defmodule LiveEx do
             assign_new(socket, key, fn -> val end)
           end)
 
+        :ok = Phoenix.PubSub.unsubscribe(unquote(pubsub_name), socket.assigns.topic)
         :ok = Phoenix.PubSub.subscribe(unquote(pubsub_name), socket.assigns.topic)
 
         socket

--- a/test/live_x_test.exs
+++ b/test/live_x_test.exs
@@ -63,6 +63,26 @@ defmodule LiveExTest do
         Example.init(state_list, context[:socket])
       end
     end
+
+    @doc """
+    As we call init in at least two places it's important to make sure that double subscription does not occur
+    otherwise it leads to double event dispatch which is harmful for events with side effects
+    """
+    test "avoids double subscription when called multiple times", context do
+      state = %{a: 1, b: "Test", c: nil}
+
+      socket = Example.init(state, context[:socket])
+      Example.init(state, socket)
+
+      event = %{
+        type: "test_event",
+        payload: "test_payload"
+      }
+
+      :ok = Example.dispatch(event.type, event.payload, socket)
+      assert_received(^event)
+      refute_receive(^event)
+    end
   end
 
   describe "dispatch" do


### PR DESCRIPTION
As we added side effects to our action/mutation we discovered that live_ex dispatches event twice. I presume it's due to the fact that init is called once in LV and then another time in LC. 
Adding unsubscription first before subscribing again, to make sure to avoid that. 